### PR TITLE
Feat/add borger dk

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -24,4 +24,4 @@ include_entire_dataset:
 
 min_sentence_length: 30
 min_docs_per_phoneme: 30
-scraping_retry_connection_limit: 5
+scraping_retry_connection_limit: 20

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -24,3 +24,4 @@ include_entire_dataset:
 
 min_sentence_length: 30
 min_docs_per_phoneme: 30
+scraping_retry_connection_limit: 5

--- a/src/tts_text/__init__.py
+++ b/src/tts_text/__init__.py
@@ -10,6 +10,7 @@ from .times import build_time_dataset
 from .lex import build_lex_dataset
 from .phoneme_covering import build_phoneme_covering_dataset
 from .sundhed_dk import build_sundhed_dk_dataset
+from .borger_dk import build_borger_dk_dataset
 
 # Fetches the version of the package as defined in pyproject.toml
 __version__ = importlib.metadata.version(__package__)
@@ -22,4 +23,5 @@ ALL_DATASET_BUILDERS: dict[str, Callable[..., list[str]]] = dict(
     lex=build_lex_dataset,
     phoneme_covering=build_phoneme_covering_dataset,
     sundhed_dk=build_sundhed_dk_dataset,
+    build_borger_dk_dataset=build_borger_dk_dataset,
 )

--- a/src/tts_text/borger_dk.py
+++ b/src/tts_text/borger_dk.py
@@ -1,0 +1,235 @@
+"""Scraping and preprocessing of the sundhed.dk text corpus."""
+
+from pathlib import Path
+from unicodedata import normalize
+from bs4 import Tag, BeautifulSoup
+from omegaconf import DictConfig
+from tqdm.auto import tqdm
+from webdriver_manager.chrome import ChromeDriverManager
+import logging
+import re
+from .utils import extract_sentences, get_soup
+
+
+BASE_URL = "https://www.borger.dk"
+SUBSITES_TO_IGNORE = [
+    "/kampagnesider/",  # Its own special subsite, with a question-answer-type
+    # navigation, which leads to articles on the main site
+]
+
+
+def build_borger_dk_dataset(cfg: DictConfig) -> list[str]:
+    """Build the sundhed.dk dataset.
+
+    Args:
+        cfg: The Hydra configuration object.
+
+    Returns:
+        A list of articles from sundhed.dk.
+    """
+    # Load dataset if it already exists
+    dataset_path = Path(cfg.dirs.data) / cfg.dirs.raw / "sundhed_dk.txt"
+    if dataset_path.exists():
+        with dataset_path.open("r", encoding="utf-8") as f:
+            return f.read().split("\n")
+
+    # Install the Chrome driver, if it isn't already installed
+    logging.getLogger("WDM").setLevel(logging.WARNING)
+    ChromeDriverManager().install()
+
+    # Get the overall categories from the front page
+    # retry if it fails
+    soup: BeautifulSoup = BeautifulSoup("")
+    while not soup.contents:
+        soup = get_soup(url=BASE_URL, dynamic=True)
+
+    category_urls = [
+        BASE_URL + url_suffix.contents[1].attrs["href"]
+        for url_suffix in soup.find_all("li", class_="col-12")
+    ]
+
+    # Extract all articles
+    all_articles: list[str] = list()
+    found_urls: list[str] = list()
+    desc = "Extracting articles from sundhed.dk"
+    for category_url in tqdm(category_urls, desc=desc, leave=True):
+        # Borger.dk is structured in to categories, which are structured in to
+        # subcategories, which are structured in to articles. Every article contains
+        # a text, and a link to another article. The links go both up, down and
+        # sideways in the hierarchy, so we need to restrict ourselves to one category
+        # at a time, and only follow links downwards, otherwise the recursion will
+        # never end. This is why we use the category variable.
+        category = category_url.split("/")[-1]
+        category_articles, found_urls = extract_all_category_articles(
+            url=category_url, category=category, found_urls=found_urls
+        )
+        all_articles.extend(category_articles)
+
+    # Split the articles into sentences
+    dataset = extract_sentences(
+        corpus=all_articles, min_sentence_length=cfg.min_sentence_length
+    )
+
+    # Ensure sentences end with appropriate punctuation
+    dataset = [
+        sentence + "." if re.match(r".*[.?!]$", sentence) is None else sentence
+        for sentence in dataset
+    ]
+
+    # Remove sentences not starting with a capital letter
+    dataset = [sentence for sentence in dataset if sentence[0].isupper()]
+
+    # Save the dataset
+    with dataset_path.open("w", encoding="utf-8") as f:
+        f.write("\n".join(dataset))
+
+    return dataset
+
+
+def extract_all_category_articles(
+    url: str, category: str, parsed_urls: list[str] = [], found_urls=[]
+) -> tuple[list[str], list[str]]:
+    """Extract all articles from a category page.
+
+    These pages have arbitrarily nested subcategories, so this function is called
+    recursively.
+
+    Args:
+        url: The URL of the category page.
+        parsed_urls: A list of URLs that have already been parsed.
+
+    Returns:
+        A list of articles from the category.
+    """
+    # Often we receive no page when we try to access a page, so we retry a few times
+    # but we give up fairly fast due to time constraints.
+    soup: BeautifulSoup = BeautifulSoup("")
+    # TODO: add to config
+    attempts_left = 5
+    while not soup.contents and attempts_left > 0:
+        soup = get_soup(url=url, dynamic=True)
+        attempts_left -= 1
+
+    if attempts_left == 0:
+        return [], found_urls
+
+    # Get links in collapsable sidebar
+    subcategory_urls: list[str] = []
+    for collapsed_div in soup.find_all(name="div", class_="collapse"):
+        if isinstance(collapsed_div, Tag):
+            # Find all the good links in the sidebar.
+            subcategory_urls.extend(
+                [
+                    BASE_URL + url_suffix.attrs["href"]
+                    for url_suffix in collapsed_div.find_all(
+                        name="a", class_="nav-link"
+                    )
+                    if (
+                        url_suffix.attrs is not None  # Its a link
+                        and category
+                        in url_suffix.attrs["href"]  # Only links to the same category
+                        and url_suffix.attrs["href"]
+                        not in url  # We are not going up in the hierarchy
+                        and not any(
+                            subsite in url_suffix.attrs["href"]
+                            for subsite in SUBSITES_TO_IGNORE
+                        )  # Alternative navigation hierarchies
+                        and BASE_URL
+                        not in url_suffix.attrs["href"]  # Links which contain
+                        # the base url are not articles, but are javascript-based
+                        # navigation or links to files hosted on borger.dk
+                        and BASE_URL + url_suffix.attrs["href"]
+                        not in found_urls  # We have not already found this link
+                    )
+                ]
+            )
+
+    # If there are no new subcategories, then we assume that the page has an article
+    # and we extract it. Any article is accompanied by a link to another
+    # article, so we open these and extract them as well
+    if not subcategory_urls:
+        subcategory_articles: list[str] = list()
+        articles_to_return: list[str] = list()
+        for content_div in soup.find_all(name="div", class_="content-text"):
+            # Extract the article
+            article_str = ""
+            for paragraph in content_div.find_all(name="p"):
+                article_str += paragraph.text + " "
+
+            # Clean the final article text
+            article_str = normalize("NFKC", article_str).replace("–", "-").strip()
+            article_str = re.sub(
+                r"[^a-zA-Z0-9æøåéÉÆØÅ.,\-?!:\n\/()\[\] ]%\"\'", "", article_str
+            )
+
+            # Some articles are only a link to another article, so we ignore them
+            if article_str:
+                articles_to_return.append(article_str)
+
+            # Find all the good links to nested articles.
+            for list_link in content_div.find_all(name="ul", class_="list--links"):
+                # TODO: make list comprehension into function
+                subcategory_urls.extend(
+                    [
+                        BASE_URL + url_suffix.attrs["href"]
+                        for url_suffix in list_link.find_all(name="a")
+                        if (
+                            url_suffix.attrs is not None  # Its a link
+                            and category
+                            in url_suffix.attrs[
+                                "href"
+                            ]  # Only links to the same category
+                            and url_suffix.attrs["href"]
+                            not in url  # We are not going up in the hierarchy
+                            and not any(
+                                subsite in url_suffix.attrs["href"]
+                                for subsite in SUBSITES_TO_IGNORE
+                            )  # Alternative navigation hierarchies
+                            and BASE_URL
+                            not in url_suffix.attrs["href"]  # Links which contain
+                            # the base url are not articles, but are javascript-based
+                            # navigation or links to files hosted on borger.dk
+                            and BASE_URL + url_suffix.attrs["href"]
+                            not in found_urls  # We have not already found this link
+                        )
+                    ]
+                )
+
+            # Follow the good links to nested articles
+            desc = f"Extracting articles from {url}"
+            parsed_urls.append(url)
+            found_urls.extend(subcategory_urls + [url])
+            for subcategory_url in tqdm(subcategory_urls, desc=desc, leave=False):
+                if subcategory_url in parsed_urls:
+                    continue
+                extracted_articles, found_urls = extract_all_category_articles(
+                    url=subcategory_url,
+                    category=category,
+                    parsed_urls=parsed_urls,
+                    found_urls=found_urls,
+                )
+                subcategory_articles.extend(extracted_articles)
+
+        # We have now followed all the good links in the articles hence
+        # subcategory_articles should now only contain articles. We add
+        # these to the articles we have already found in this article
+
+        return articles_to_return + subcategory_articles, found_urls
+
+    # If it wasn't and article then we recursively extract all articles from the
+    # subcategories
+    desc = f"Extracting articles from {url}"
+    category_articles: list[str] = list()
+    parsed_urls.append(url)
+    found_urls.extend(subcategory_urls + [url])
+    for subcategory_url in tqdm(subcategory_urls, desc=desc, leave=False):
+        if subcategory_url in parsed_urls:
+            continue
+        subcategory_articles, found_urls = extract_all_category_articles(
+            url=subcategory_url,
+            category=category,
+            parsed_urls=parsed_urls,
+            found_urls=found_urls,
+        )
+        category_articles.extend(subcategory_articles)
+    return category_articles, found_urls

--- a/src/tts_text/borger_dk.py
+++ b/src/tts_text/borger_dk.py
@@ -240,8 +240,8 @@ def get_suitable_links(
         - to the same category
         - that are not going up in the hierarchy
         - that are not referencing alternative navigation hierarchies
-        - that are not links to files hosted on borger.dk nor javascript-based
-            navigation links
+        - that are not links to files hosted on borger.dk
+        - that are not javascript-based navigation links
         - that have not already been found
     Args:
         list_link: The list HTML element, containing the links.

--- a/src/tts_text/borger_dk.py
+++ b/src/tts_text/borger_dk.py
@@ -13,8 +13,9 @@ from .utils import extract_sentences, get_soup
 
 BASE_URL = "https://www.borger.dk"
 SUBSITES_TO_IGNORE = [
-    "/kampagnesider/",  # Its own special subsite, with a question-answer-type
-    # navigation, which leads to articles on the main site
+    # Its own special subsite, with a question-answer-type navigation, which leads
+    # to articles on the main site
+    "/kampagnesider/",  
 ]
 
 

--- a/src/tts_text/borger_dk.py
+++ b/src/tts_text/borger_dk.py
@@ -126,7 +126,12 @@ def extract_all_articles(
     for collapsed_div in soup.find_all(name="div", class_="collapse"):
         if isinstance(collapsed_div, Tag):
             urls_to_search.extend(
-                get_suitable_links(collapsed_div, category, url, found_urls)
+                get_suitable_links(
+                    list_link=collapsed_div,
+                    category=category,
+                    url=url,
+                    found_urls=found_urls,
+                )
             )
 
     # If there are no new subcategories, then we assume that the page has an article
@@ -146,14 +151,20 @@ def extract_all_articles(
                 r"[^a-zA-Z0-9æøåéÉÆØÅ.,\-?!:\n\/()\[\] ]%\"\'", "", article_str
             )
 
-            # Some articles are only a link to another article, so we ignore them
+            # Some articles are only a link to another article, i.e. they contain
+            # no text. This results in emptry strings, which we ignore.
             if article_str:
                 scraped_text_on_current_page.append(article_str)
 
             # Find all the good links to nested articles.
             for list_link in content_div.find_all(name="ul", class_="list--links"):
                 urls_to_search.extend(
-                    get_suitable_links(list_link, category, url, found_urls)
+                    get_suitable_links(
+                        list_link=list_link,
+                        category=category,
+                        url=url,
+                        found_urls=found_urls,
+                    )
                 )
 
             accumulated_articles, found_urls = follow_links_and_extract_articles(

--- a/src/tts_text/borger_dk.py
+++ b/src/tts_text/borger_dk.py
@@ -243,6 +243,7 @@ def get_suitable_links(
         - that are not links to files hosted on borger.dk
         - that are not javascript-based navigation links
         - that have not already been found
+        
     Args:
         list_link: The list HTML element, containing the links.
         category: The category of the links.

--- a/src/tts_text/borger_dk.py
+++ b/src/tts_text/borger_dk.py
@@ -239,7 +239,7 @@ def get_suitable_links(
     Suitable links are links:
         - to the same category
         - that are not going up in the hierarchy
-        - that are not refering alternative navigation hierarchies
+        - that are not referencing alternative navigation hierarchies
         - that are not links to files hosted on borger.dk nor javascript-based
             navigation links
         - that have not already been found

--- a/src/tts_text/borger_dk.py
+++ b/src/tts_text/borger_dk.py
@@ -258,7 +258,7 @@ def get_suitable_links(
         BASE_URL + url_suffix.attrs["href"]
         for url_suffix in list_link.find_all(name="a")
         if (
-            url_suffix.attrs is not None  # Its a link
+            url_suffix.attrs is not None  # It's a link
             and category in url_suffix.attrs["href"]  # Only links to the same category
             and url_suffix.attrs["href"]
             not in url  # We are not going up in the hierarchy

--- a/src/tts_text/borger_dk.py
+++ b/src/tts_text/borger_dk.py
@@ -244,7 +244,7 @@ def get_suitable_links(
             navigation links
         - that have not already been found
     Args:
-        list_link: The list of links.
+        list_link: The list HTML element, containing the links.
         category: The category of the links.
         url: The URL of the page where the list of links was found.
         found_urls: The URLs that have already been found, but not necessarily

--- a/src/tts_text/borger_dk.py
+++ b/src/tts_text/borger_dk.py
@@ -259,21 +259,23 @@ def get_suitable_links(
     Returns:
         A list of suitable links.
     """
-    return [
-        BASE_URL + url_suffix.attrs["href"]
-        for url_suffix in list_link.find_all(name="a")
-        if (
-            url_suffix.attrs is not None  # It's a link
-            and category in url_suffix.attrs["href"]  # Only links to the same category
-            and url_suffix.attrs["href"]
-            not in url  # We are not going up in the hierarchy
-            and not any(
-                subsite in url_suffix.attrs["href"] for subsite in SUBSITES_TO_IGNORE
-            )  # Alternative navigation hierarchies
-            and BASE_URL not in url_suffix.attrs["href"]  # Links which contain
-            # the base url are not articles, but are javascript-based
-            # navigation or links to files hosted on borger.dk
-            and BASE_URL + url_suffix.attrs["href"]
-            not in found_urls  # We have not already found this link
+    suitable_links: list[str] = list()
+    for url_suffix in list_link.find_all(name="a"):
+        is_a_link = url_suffix.attrs is not None
+        is_same_category = category in url_suffix.attrs["href"]
+        is_not_going_up_in_hierarchy = url_suffix.attrs["href"] not in url
+        is_not_alternative_navigation = not any(
+            subsite in url_suffix.attrs["href"] for subsite in SUBSITES_TO_IGNORE
         )
-    ]
+        is_not_file_or_javascript = BASE_URL not in url_suffix.attrs["href"]
+        is_not_already_found = BASE_URL + url_suffix.attrs["href"] not in found_urls
+        if (
+            is_a_link
+            and is_same_category
+            and is_not_going_up_in_hierarchy
+            and is_not_alternative_navigation
+            and is_not_file_or_javascript
+            and is_not_already_found
+        ):
+            suitable_links.append(BASE_URL + url_suffix.attrs["href"])
+    return suitable_links

--- a/src/tts_text/borger_dk.py
+++ b/src/tts_text/borger_dk.py
@@ -23,7 +23,8 @@ def build_borger_dk_dataset(cfg: DictConfig) -> list[str]:
     """Build the borger.dk dataset.
 
     Args:
-        cfg: The Hydra configuration object.
+        cfg:
+            The Hydra configuration object.
 
     Returns:
         A list of articles from borger.dk.
@@ -195,13 +196,20 @@ def follow_links_and_extract_articles(
     """Follow links and extract articles.
 
     Args:
-        cfg: The Hydra configuration object.
-        category: The category of the page.
-        accumulated_articles: The articles that have already been accumulated.
-        top_url: The top URL.
-        urls_to_search: The URLs to search.
-        parsed_urls: The URLs that have already been parsed.
-        found_urls: The URLs that have already been found, but not necessarily
+        cfg:
+            The Hydra configuration object.
+        category:
+            The category of the page.
+        accumulated_articles:
+            The articles that have already been accumulated.
+        top_url:
+            The top URL.
+        urls_to_search:
+            The URLs to search.
+        parsed_urls:
+            The URLs that have already been parsed.
+        found_urls:
+            The URLs that have already been found, but not necessarily
             parsed.
 
     Returns:
@@ -238,10 +246,14 @@ def get_suitable_links(
         - that have not already been found
 
     Args:
-        list_link: The list HTML element, containing the links.
-        category: The category of the links.
-        url: The URL of the page where the list of links was found.
-        found_urls: The URLs that have already been found, but not necessarily
+        list_link:
+            The list HTML element, containing the links.
+        category:
+            The category of the links.
+        url:
+            The URL of the page where the list of links was found.
+        found_urls:
+            The URLs that have already been found, but not necessarily
             parsed.
 
     Returns:

--- a/src/tts_text/borger_dk.py
+++ b/src/tts_text/borger_dk.py
@@ -101,11 +101,14 @@ def extract_all_articles(
     `get_suitable_links` for the criteria for suitable links.
 
     Args:
-        cfg: The Hydra configuration object.
-        category: The category of the page.
-        parsed_urls: A list of URLs that have already been parsed.
-        found_urls: A list of URLs that have already been found, but not necessarily
-            parsed.
+        cfg: 
+            The Hydra configuration object.
+        category: 
+            The category of the page.
+        parsed_urls: 
+            A list of URLs that have already been parsed.
+        found_urls: 
+            A list of URLs that have already been found, but not necessarily parsed.
 
     Returns:
         A list of articles, and an updated list of found URLs.

--- a/src/tts_text/utils.py
+++ b/src/tts_text/utils.py
@@ -196,7 +196,7 @@ def get_soup(
             soup = BeautifulSoup(html, "html.parser")
     elif retries > 0:
         for _ in range(retries):
-            soup = get_soup(url=url, dynamic=True)
+            soup = BeautifulSoup(html, "html.parser")
             if soup.contents:
                 break
     else:

--- a/src/tts_text/utils.py
+++ b/src/tts_text/utils.py
@@ -199,6 +199,8 @@ def get_soup(
             soup = BeautifulSoup(html, "html.parser")
             if soup.contents:
                 break
+        else:
+            raise RuntimeError(f"Could not parse the URL {url}.")
     else:
         soup = BeautifulSoup(html, "html.parser")
     return soup


### PR DESCRIPTION
This PR depends on #9 .

Adds the borger.dk-scrape. borger.dk, is not a simple tree structure of categories/subcategories/articles, but rather:

- A set of different adjacent navigation hierarchies. (Regular tree hierarchy / user-questionaires / javascript-toggle-bullshit)
- These hierarchies are navigating a single set of categories/subcategories.
- Each subcategory contains a set of nested articles.
- Each article is a text and a link, and the link navigates up, down and sideways in the category/subcategory/nested article hierarchy (and also to adjacent hierarchies)

To mitigate this we:
- Pick one navigation hierarchy (the regular tree hierarchy), and avoid the others.
- Process each category analogous to how sundhed.dk was scraped, with the following additions:
    -  We make sure to only follow links downward or sideways within a category/subcategory, i.e. that we do not leave a category once we've entered it.
    - Since there are many ways to navigate to the same article we store which urls we've visited, to avoid parsing them twice.
