### PR TITLE
fix: retry in case we get errors when dynamically getting soup

### DIFF
--- a/src/tts_text/borger_dk.py
+++ b/src/tts_text/borger_dk.py
@@ -273,7 +273,7 @@ def get_suitable_links(
     """
     suitable_links: list[str] = list()
     for url_suffix in list_link.find_all(name="a"):
-        is_a_link = url_suffix.attrs is not None
+        is_a_link = url_suffix.attrs is not None and "href" in url_suffix.attrs
         is_same_category = category in url_suffix.attrs["href"]
         is_not_going_up_in_hierarchy = url_suffix.attrs["href"] not in url
         is_not_alternative_navigation = not any(

--- a/src/tts_text/borger_dk.py
+++ b/src/tts_text/borger_dk.py
@@ -286,7 +286,7 @@ def get_suitable_links(
         is_not_file_or_javascript = BASE_URL not in url_suffix.attrs["href"]
         is_not_going_outside_borger_dk = not (
             url_suffix.attrs["href"].startswith("http")
-            and "borger.dk" not in url_suffix.attrs["href"]  # avoid http(s) distinction
+            and "www.borger.dk" not in url_suffix.attrs["href"]
         )
         is_not_already_found = BASE_URL + url_suffix.attrs["href"] not in found_urls
         is_http_link = url_suffix.attrs["href"].startswith(

--- a/src/tts_text/borger_dk.py
+++ b/src/tts_text/borger_dk.py
@@ -273,8 +273,12 @@ def get_suitable_links(
     """
     suitable_links: list[str] = list()
     for url_suffix in list_link.find_all(name="a"):
+        # Some links do not have an href attribute, and are therefore not links
         is_a_link = url_suffix.attrs is not None and "href" in url_suffix.attrs
-        is_same_category = category in url_suffix.attrs["href"]
+        if not is_a_link:
+            continue
+
+        is_same_category = category in url_suffix.attrs.get("href")
         is_not_going_up_in_hierarchy = url_suffix.attrs["href"] not in url
         is_not_alternative_navigation = not any(
             subsite in url_suffix.attrs["href"] for subsite in SUBSITES_TO_IGNORE

--- a/src/tts_text/borger_dk.py
+++ b/src/tts_text/borger_dk.py
@@ -254,6 +254,7 @@ def get_suitable_links(
         - that are not referencing alternative navigation hierarchies
         - that are not links to files hosted on borger.dk
         - that are not javascript-based navigation links
+        - that are not links to pages outside borger.dk
         - that have not already been found
 
     Args:
@@ -279,14 +280,26 @@ def get_suitable_links(
             subsite in url_suffix.attrs["href"] for subsite in SUBSITES_TO_IGNORE
         )
         is_not_file_or_javascript = BASE_URL not in url_suffix.attrs["href"]
+        is_not_going_outside_borger_dk = not (
+            url_suffix.attrs["href"].startswith("http")
+            and "borger.dk" not in url_suffix.attrs["href"]  # avoid http(s) distinction
+        )
         is_not_already_found = BASE_URL + url_suffix.attrs["href"] not in found_urls
+        is_http_link = url_suffix.attrs["href"].startswith(
+            "http"
+        ) and not url_suffix.attrs["href"].startswith("https")
         if (
             is_a_link
             and is_same_category
             and is_not_going_up_in_hierarchy
             and is_not_alternative_navigation
             and is_not_file_or_javascript
+            and is_not_going_outside_borger_dk
             and is_not_already_found
         ):
-            suitable_links.append(BASE_URL + url_suffix.attrs["href"])
+            # Some links are http links, which are not relative to the base URL
+            if is_http_link:
+                suitable_links.append(url_suffix.attrs["href"])
+            else:
+                suitable_links.append(BASE_URL + url_suffix.attrs["href"])
     return suitable_links

--- a/src/tts_text/utils.py
+++ b/src/tts_text/utils.py
@@ -162,7 +162,8 @@ def get_soup(
         options = Options()
         options.add_argument("--headless")
         driver = webdriver.Chrome(options=options)
-        while not html:
+        retries_left = 5
+        while retries_left > 0 and not html:
             try:
                 driver.get(url=url)
                 html = driver.page_source
@@ -172,6 +173,7 @@ def get_soup(
             except WebDriverException:
                 logger.warning(f"Could not get soup from {url}.")
                 html = ""
+            retries_left -= 1
     else:
         response = rq.get(url=url)
 

--- a/src/tts_text/utils.py
+++ b/src/tts_text/utils.py
@@ -157,19 +157,21 @@ def get_soup(
     if not (retries is None or retries >= 0):
         raise ValueError("Number of retries must be non-negative.")
 
+    html: str = ""
     if dynamic:
         options = Options()
         options.add_argument("--headless")
         driver = webdriver.Chrome(options=options)
-        try:
-            driver.get(url=url)
-            html = driver.page_source
-        except TimeoutException:
-            logger.warning(f"Timed out while getting soup from {url}.")
-            html = ""
-        except WebDriverException:
-            logger.warning(f"Could not get soup from {url}.")
-            html = ""
+        while not html:
+            try:
+                driver.get(url=url)
+                html = driver.page_source
+            except TimeoutException:
+                logger.warning(f"Timed out while getting soup from {url}.")
+                html = ""
+            except WebDriverException:
+                logger.warning(f"Could not get soup from {url}.")
+                html = ""
     else:
         response = rq.get(url=url)
 
@@ -189,6 +191,9 @@ def get_soup(
             )
 
         html = response.text
+
+    if not html:
+        return BeautifulSoup("")
 
     soup: BeautifulSoup = BeautifulSoup("")
     if retries is None:


### PR DESCRIPTION
In the scrape i made last night the borger.dk scrape was almost empty due to `TimeoutException` which resulted in empty `html`. Retrying a couple times fixes the issue.

AND

Sometime borger.dk refers to itself via http instead of https, which means we ended up scraping some pages two times. Furthermore external links were not removed during `get_suitable_links`, but they were not followed as we prepended `https://www.borger.dk` to them. 